### PR TITLE
Various fixes to make it work for me

### DIFF
--- a/gltf-viewer.py
+++ b/gltf-viewer.py
@@ -114,7 +114,7 @@ class Viewer(ShowBase):
     def get_render_image(self):
         self.graphicsEngine.render_frame()
         #self.texture.write('tex.png')
-        return self.texture.getRamImage().get_data(), self.texture.get_x_size(), self.texture.get_y_size()
+        return memoryview(self.texture.get_ram_image_as("RGB")), self.texture.get_x_size(), self.texture.get_y_size()
 
 
 if __name__ == '__main__':

--- a/gltf-viewer.py
+++ b/gltf-viewer.py
@@ -66,6 +66,7 @@ class Viewer(ShowBase):
         self.view_region = None
 
         fbprops = FrameBufferProperties(FrameBufferProperties.get_default())
+        fbprops.set_srgb_color(True)
         fbprops.set_alpha_bits(0)
         wp = WindowProperties.size(sx, sy)
         flags = GraphicsPipe.BF_refuse_window


### PR DESCRIPTION
These are the fixes I suggested in IRC.  With these fixes I get results that look (more or less) the same in Blender and Panda3D.
I also removed the get_data() call in favour of using the buffer interface since that should prevent a redundant copy operation.

If you want to avoid Panda doing the component swap, then I suggest you change it back to BGR and change glTexImage2D call to use GL_BGR as well.

Note that this relies on Panda3D 1.9 features so won't work in Panda3D 1.8.1.
